### PR TITLE
fix PteroClient.addSocketServer()

### DIFF
--- a/src/client/PteroClient.js
+++ b/src/client/PteroClient.js
@@ -98,11 +98,15 @@ class PteroClient extends EventEmitter {
 
     /**
      * Adds a server or an array of servers to be connected to websockets.
-     * @param {string[]} ids The identifier of the server, or an array of server identifiers.
+     * @param {string[] | string} ids The identifier of the server, or an array of server identifiers.
      * @returns {this}
      */
-    addSocketServer(...ids) {
-        this.ws.servers.concat(ids);
+    addSocketServer(ids) {
+        if (typeof ids === 'string')
+            this.ws.servers.push(ids);
+        else if (ids instanceof Array)
+            this.ws.servers.push(...ids);
+
         return this;
     }
 


### PR DESCRIPTION
Array.concat doesn't modify target array but returns new one. Not that it fixes [websockets 403 problem](https://github.com/PteroPackages/PteroJS/issues/9), but in current state `ws.servers` is unmodified after method call resulting in always empty array.