### PR TITLE
Big WebSockets refactor

### DIFF
--- a/src/client/ws/Shard.js
+++ b/src/client/ws/Shard.js
@@ -1,46 +1,75 @@
+const EventEmitter = require('events');
 const WebSocket = require('ws');
 const handle = require('./packetHandler');
 const endpoints = require('../endpoints');
 
-class Shard {
-    constructor(client, id, auth) {
+class Shard extends EventEmitter {
+    constructor(client, id) {
+        super();
+
         this.client = client;
         this.id = id;
-        this.token = auth.token;
+        this.token = null;
         this.socket = null;
         this.status = 'CLOSED';
         this.readyAt = 0;
         this.ping = -1;
         this.lastPing = 0;
-
-        this.connect(auth);
     }
 
+    /**
+     * Emit `debug` client event with given message
+     * @param {string} message Message text
+     */
     #debug(message) {
         this.client.emit('debug', `[SHARD ${this.id}] ${message}`);
     }
 
-    connect({ socket }) {
-        if (!['CLOSED', 'RECONNECTING'].includes(this.status)) return;
-        if (this.socket) this.socket = null;
-        this.socket = new WebSocket(socket);
-        this.status = 'CONNECTING';
+    /**
+     * Initialize connection and resolve after full authentication
+     * @param {WebSocketAuth?} auth WebSocket URL to connect to
+     * @returns {Promise<WebSocket>} WebSocket connection
+     */
+    connect(auth) {
+        return new Promise(async (resolve, reject) => {
+            if (!['CLOSED', 'RECONNECTING'].includes(this.status)) return;
+            if (this.socket) this.socket = null;
 
-        this.socket.on('open', () => this._onOpen());
-        this.socket.on('message', data => this._onMessage(data.toString()));
-        this.socket.on('error', error => this._onError(error));
-        this.socket.on('close', () => this._onClose());
+            if (!auth)
+                ({ data: auth } = await this.client.requests.get(endpoints.servers.ws(this.id)));
+
+            this.socket = new WebSocket(auth.socket);
+            this.status = 'CONNECTING';
+
+            this.socket.on('open', () => this._onOpen());
+            this.socket.on('message', data => this._onMessage(data.toString()));
+            this.socket.on('error', error => this._onError(error));
+            this.socket.on('close', () => this._onClose());
+
+            this.token = auth.token;
+            this.once('authSuccess', () => {
+                this.emit('serverConnect', this.socket);
+                resolve(this.socket);
+            });
+        })
     }
 
+    /**
+     * Close socket connection and start a new one
+     * @returns {Promise<WebSocket>} WebSocket connection
+     */
     async reconnect() {
         if (this.status === 'RECONNECTING') return;
         this.status = 'RECONNECTING';
-        const { data } = await this.client.requests.get(endpoints.servers.ws(this.id));
         this.socket.close(4009, 'pterojs::reconnect');
-        this.token = data.token;
-        this.connect(data);
+
+        const { data } = await this.client.requests.get(endpoints.servers.ws(this.id));
+        return this.connect(data.socket, data.token);
     }
 
+    /**
+     * Close socket connection
+     */
     disconnect() {
         if (!this.readyAt) return;
         this.socket.close(1000, 'pterojs::disconnect');
@@ -48,9 +77,35 @@ class Shard {
         this.readyAt = 0;
         this.lastPing = 0;
         this.ping = -1;
-        this.token = null;
     }
 
+    /**
+     * Get a new token from API and send it to active socket connection
+     * @returns {Promise<void>}
+     */
+    async refreshToken() {
+        return new Promise(async (resolve, reject) => {
+            if (this.status !== 'CONNECTED') return reject('Socket not connected');
+
+            // using this transitional property to avoid double token issuing during init
+            if (!this.token) {
+                const { data } = await this.client.requests.get(endpoints.servers.ws(this.id));
+                this.token = data.token;
+            }
+
+            this.send('auth', this.token);
+            this.token = null;
+            this.lastPing = Date.now();
+
+            this.once('authSuccess', () => resolve(this.socket));
+        })
+    }
+
+    /**
+     * Send a message to socket server
+     * @param {string} event Name of event
+     * @param {any|any[]|undefined} args Event data
+     */
     send(event, args) {
         if (!this.socket) throw new Error('Socket for this shard is unavailable.');
         if (!Array.isArray(args)) args = [args];
@@ -58,26 +113,29 @@ class Shard {
     }
 
     _onOpen() {
-        this.send('auth', this.token);
         this.status = 'CONNECTED';
-        this.lastPing = Date.now();
+        this.readyAt = Date.now();
+        this.refreshToken();
 
-        this.#debug('Socket connected');
+        this.#debug('Connection opened');
     }
 
     _onMessage(data) {
         if (!data) return this.#debug('Received a malformed packet');
         data = JSON.parse(data);
 
-        this.client.emit('rawPayload', data);
+        this.emit('rawPayload', data);
 
         switch (data.event) {
             case 'auth success':
                 this.ping = Date.now() - this.lastPing;
+                this.#debug('Auth token refreshed');
+                this.emit('authSuccess');
+
                 break;
 
             case 'token expiring':
-                // irrelevant
+                this.refreshToken();
                 return;
 
             case 'token expired':
@@ -85,10 +143,10 @@ class Shard {
                 break;
         }
 
-        handle(this.client, data, this.id);
+        handle(this, data, this.id);
     }
 
-    _onError({ error }) {
+    _onError(error) {
         if (!error) return;
         this.#debug(`Error received: ${error}`);
     }
@@ -98,5 +156,11 @@ class Shard {
         this.#debug('Connection closed');
     }
 }
+
+/**
+ * @typedef {object} WebSocketAuth
+ * @property {string} token
+ * @property {string} socket
+ */
 
 module.exports = Shard;

--- a/src/client/ws/WebSocketManager.js
+++ b/src/client/ws/WebSocketManager.js
@@ -1,10 +1,8 @@
 const Shard = require('./Shard');
-const endpoints = require('../endpoints');
 
 class WebSocketManager {
     constructor(client) {
         this.client = client;
-        this.servers = [];
 
         /**
          * A map of active server shards.
@@ -13,31 +11,6 @@ class WebSocketManager {
         this.shards = new Map();
         this.totalShards = 0;
         this.readyAt = 0;
-    }
-
-    async launch() {
-        if (!this.servers.length) {
-            this.client.emit('debug', '[WS] No shards to launch');
-            return;
-        }
-
-        this.client.emit('debug', `[WS] Attempting to launch ${this.servers.length} shard(s)`);
-        for (const id of this.servers) {
-            const { data } = await this.client.requests.get(endpoints.servers.ws(id));
-            try {
-                const shard = new Shard(this.client, id, data);
-                this.shards.set(id, shard);
-                this.totalShards++;
-            } catch (err) {
-                this.client.emit(
-                    'debug',
-                    `[WS] Shard '${id}' failed to launch\n[WS] ${err.message}`
-                );
-            }
-        }
-
-        this.readyAt = Date.now();
-        this.client.emit('ready');
     }
 
     destroy() {
@@ -54,6 +27,37 @@ class WebSocketManager {
         let sum = 0;
         for (const shard of this.shards.values()) sum += shard.ping;
         return sum / this.totalShards;
+    }
+
+    /**
+     * Adds a server to be connected to websockets.
+     * @param {string} id The identifier of the server.
+     * @returns {Shard} Created (or reused) shard.
+     */
+    createShard(id) {
+        if (this.shards.has(id))
+            return this.shards(id);
+
+        const shard = new Shard(this.client, id);
+        this.shards.set(id, shard);
+        this.totalShards++;
+
+        return shard;
+    }
+
+    /**
+     * Removes a server from websocket connections.
+     * @param {string} id The identifier of the server.
+     * @returns {boolean} Whether shard was removed.
+     */
+    removeShard(id) {
+        if (!this.shards.has(id))
+            return false;
+
+        this.shards.delete(id);
+        this.totalShards--;
+
+        return true;
     }
 }
 

--- a/src/client/ws/packetHandler.js
+++ b/src/client/ws/packetHandler.js
@@ -1,48 +1,44 @@
-function handle(client, { event, args }, id) {
-    function getServer(id) {
-        return client.servers.cache.get(id);
-    }
-
+function handle(client, { event, args }) {
     switch (event) {
         case 'auth success':
-            return client.emit('serverConnect', getServer(id));
+            return client.emit('authSuccess');
 
         case 'status':
-            return client.emit('statusUpdate', getServer(id), ...args);
+            return client.emit('statusUpdate', ...args);
 
         case 'console output':
-            return client.emit('serverOutput', id, ...args);
+            return client.emit('serverOutput', ...args);
 
         case 'daemon message':
-            return client.emit('daemonMessage', getServer(id), ...args);
+            return client.emit('daemonMessage', ...args);
 
         case 'install started':
-            return client.emit('installStart', id);
+            return client.emit('installStart');
 
         case 'install output':
-            return client.emit('installOutput', id, ...args);
+            return client.emit('installOutput', ...args);
 
         case 'install completed':
-            return client.emit('installComplete', id);
+            return client.emit('installComplete');
 
         case 'stats':
-            return client.emit('statsUpdate', getServer(id), ...args);
+            return client.emit('statsUpdate', JSON.parse(args));
 
         case 'transferLogs':
         case 'transferStatus':
-            return client.emit('transferUpdate', id, ...args);
+            return client.emit('transferUpdate', ...args);
 
         case 'backup completed':
             let backup = {};
             if (args.length) backup = getServer(id).backups._patch(args[0]);
-            return client.emit('backupComplete', getServer(id), backup);
+            return client.emit('backupComplete', backup);
 
         case 'token expired':
-            return client.emit('serverDisconnect', id);
+            return client.emit('serverDisconnect');
 
         case 'daemon error':
         case 'jwt error':
-            return client.emit('error', id, ...args);
+            return client.emit('error', ...args);
 
         default:
             return client.emit('debug', `[SHARD ${id}] Received unknown event: '${event}'`);

--- a/src/client/ws/packetHandler.js
+++ b/src/client/ws/packetHandler.js
@@ -1,3 +1,5 @@
+const caseConv = require('../../util/caseConv');
+
 function handle(client, { event, args }) {
     switch (event) {
         case 'auth success':
@@ -22,7 +24,9 @@ function handle(client, { event, args }) {
             return client.emit('installComplete');
 
         case 'stats':
-            return client.emit('statsUpdate', JSON.parse(args));
+            const stats = JSON.parse(args);
+            stats.network = caseConv.camelCase(stats.network);
+            return client.emit('statsUpdate', caseConv.camelCase(stats));
 
         case 'transferLogs':
         case 'transferStatus':

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -227,11 +227,56 @@ export type WebSocketStatus =
     | 'RECONNECTING'
     | 'CONNECTED';
 
-export class Shard {
+export interface ShardCommands {
+    'auth': [token: string]
+    'send stats': undefined
+    'send logs': undefined
+    'set state': [state: PowerState]
+    'send command': [command: string]
+}
+
+export interface ServerStats {
+    cpu_absolute: number;
+    disk_bytes: number;
+    memory_bytes: number;
+    memory_limit_bytes: number;
+    network: {
+        rx_bytes: number;
+        tx_bytes: number;
+    };
+    state: string;
+    uptime: number;
+}
+
+export interface ShardEvents {
+    debug:              [message: string];
+    error:              [id: string, error: any];
+
+    tokenRefresh:       [void];
+
+    authSuccess:        [];
+    serverConnect:      [socket: WebSocket];
+    serverOutput:       [output: string];
+    serverDisconnect:   [];
+
+    statusUpdate:       [status: string];
+    statsUpdate:        [stats: ServerStats];
+    transferUpdate:     [data: any];
+
+    installStart:       [];
+    installOutput:      [output: string];
+    installComplete:    [];
+
+    backupComplete:     [backup: Partial<Backup>];
+
+    daemonMessage:      [message: any];
+}
+
+export class Shard extends EventEmitter {
     constructor(client: PteroClient, id: string, auth: WebSocketAuth);
     client: PteroClient;
     id: string;
-    token: string;
+    token: string | null;
     socket: WebSocket | null;
     status: WebSocketStatus;
     readyAt: number;
@@ -239,14 +284,23 @@ export class Shard {
     lastPing: number;
 
     #debug(message: string): void;
-    connect({ socket }: WebSocketAuth): void;
-    reconnect(): Promise<void>;
+    connect(auth?: WebSocketAuth): Promise<WebSocket>;
+    reconnect(): Promise<WebSocket>;
+    refreshToken(): Promise<void>;
     disconnect(): void;
-    send(event: string, args: string[]): void;
+    send<K extends keyof ShardCommands>(event: K, args: ShardCommands[K]): void;
     _onOpen(): void;
     _onMessage({ data }:{ data: string }): void;
     _onError({ error }: any): void;
     _onClose(): void;
+
+    emit<E extends keyof ShardEvents>(event: E, ...args: ShardEvents[E]): boolean;
+    on<E extends keyof ShardEvents>(event: E, listener: (...args: ShardEvents[E]) => any): this;
+    on<T, E extends keyof ShardEvents>(event: E, listener: (...args: ShardEvents[E]) => T): this;
+    once<E extends keyof ShardEvents>(event: E, listener: (...args: ShardEvents[E]) => any): this;
+    once<T, E extends keyof ShardEvents>(events: E, listener: (...args: ShardEvents[E]) => T): this;
+    off<E extends keyof ShardEvents>(event: E, listener: (...args: ShardEvents[E]) => any): this;
+    off<T, E extends keyof ShardEvents>(event: E, listener: (...args: ShardEvents[E]) => T): this;
 }
 
 export class WebSocketManager {
@@ -403,22 +457,6 @@ export interface ClientEvents {
     debug:            [message: string];
     error:            [id: string, error: any];
     ready:            [];
-
-    serverConnect:    [server: ClientServer];
-    serverOutput:     [id: string, output: any];
-    serverDisconnect: [id: string];
-
-    statusUpdate:     [server: ClientServer, status: string];
-    statsUpdate:      [server: ClientServer, stats: any];
-    transferUpdate:   [id: string, data: any];
-
-    installStart:     [id: string];
-    installOutput:    [id: string, output: any];
-    installComplete:  [id: string];
-
-    backupComplete:   [server: ClientServer, backup: Partial<Backup>];
-
-    daemonMessage:    [id: string, message: any];
 }
 
 export class PteroClient extends EventEmitter {
@@ -435,8 +473,8 @@ export class PteroClient extends EventEmitter {
 
     connect(): Promise<boolean>;
     fetchClient(): Promise<ClientUser>;
-    addSocketServer(...ids: string[]): this;
-    removeSocketServer(id: string): this;
+    addSocketServer<T extends string | string[]>(ids: T): T extends string[] ? Shard[] : Shard;
+    removeSocketServer(id: string): boolean;
     disconnect(): void;
 
     emit<E extends keyof ClientEvents>(event: E, ...args: ClientEvents[E]): boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -244,13 +244,13 @@ export interface ShardCommands {
 }
 
 export interface ServerStats {
-    cpu_absolute: number;
-    disk_bytes: number;
-    memory_bytes: number;
-    memory_limit_bytes: number;
+    cpuAbsolute: number;
+    diskBytes: number;
+    memoryBytes: number;
+    memoryLimitBytes: number;
     network: {
-        rx_bytes: number;
-        tx_bytes: number;
+        rxBytes: number;
+        txBytes: number;
     };
     state: string;
     uptime: number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -295,7 +295,7 @@ export class Shard extends EventEmitter {
     connect(auth?: WebSocketAuth): Promise<WebSocket>;
     reconnect(): Promise<WebSocket>;
     refreshToken(): Promise<void>;
-    disconnect(): void;
+    disconnect(): Promise<void>;
     send<K extends keyof ShardCommands>(event: K, args: ShardCommands[K]): void;
     _onOpen(): void;
     _onMessage({ data }:{ data: string }): void;


### PR DESCRIPTION
There's a result of my thoughts I commented on #11:

- Made auth token refresh while expiring instead of constant full reconnects, which may miss some data
- Added `Shard.refreshToken()` method
- `Shard.connect()`, `Shard.reconnect()` and `Shard.refreshToken()` new return promises resolved after successful auth
- Removed `ws` option from config and made all socket connections manual with `client.addSocketServer().connect()`
- Moved events from PteroClient to Shard, added typings for them
- Added typings for `Shard.send()` commands and `ServerStats` from `statsUpdate` event
- Documented most of `Shard` methods
- Fixed minor stuff I stumbled upon (ping, readyAt and such)

![](https://i.imgur.com/LUCKGFP.gif)

Open to any discussions, really prefer if you'd pinged me on Discord instead of comments here :)

---

Test code:
```ts
import { PteroClient, ServerStats } from './PteroJS';

const wait = (delay: number) => new Promise(resolve => setTimeout(resolve, delay))

async function run() {
	const client = new PteroClient('-snip-', '-snip-')
	await client.connect()

	const shard = client.addSocketServer('d7d01832')
	shard.on('serverConnect', socket => console.log(`socket connected for ${shard.id}: ${socket.url}`))
	shard.on('serverDisconnect', () => console.log(`socket disconnected for ${shard.id}`))

	const socket = await shard.connect()

	console.log('listening stats for 3 seconds...')
	const logStats = (stats: ServerStats) => console.log(`${shard.id}'s cpu: ${stats.cpu_absolute}`)
	shard.on('statsUpdate', logStats)
	await wait(3000)
	shard.off('statsUpdate', logStats)

	// dont't forget to reset console colors
	shard.on('serverOutput', (output) => console.log(`${shard.id}'s output: ${output}\x1b[0m`))
	shard.send('send command', ['hello'])

	await shard.disconnect()
	await shard.connect()

	shard.send('send command', ['hello after reconnection'])
}

run()
```

Result:

![](https://i.imgur.com/pdNw68p.png)
![](https://i.imgur.com/GqrTAxD.png)